### PR TITLE
chore: bump virgil-crypto-c to 0.19.0-rc.11, release 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-# Travis CI is deprecated for this repository.
-# CI has been migrated to GitHub Actions in .github/workflows.
-language: minimal
-script:
-  - echo "CI migrated to GitHub Actions (.github/workflows)."

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript {
 
             // Virgil
             virgilSdk       : '7.5.0',
-            virgilCrypto    : '0.19.0-rc.8',
+            virgilCrypto    : '0.19.0-rc.10',
 
             // Serializer
             gson            : '2.10.1',

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ buildscript {
             gradle          : '8.7',
 
             // Virgil
-            virgilSdk       : '7.4.0',
-            virgilCrypto    : '0.17.2',
+            virgilSdk       : '7.5.0',
+            virgilCrypto    : '0.19.0-rc.8',
 
             // Serializer
             gson            : '2.10.1',
@@ -113,7 +113,7 @@ allprojects {
 }
 
 final String BASE_VIRGIL_PACKAGE = 'com.virgilsecurity'
-final String SDK_VERSION = '0.3.0'
+final String SDK_VERSION = '0.4.0'
 
 subprojects {
     group = BASE_VIRGIL_PACKAGE

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript {
 
             // Virgil
             virgilSdk       : '7.5.0',
-            virgilCrypto    : '0.19.0-rc.10',
+            virgilCrypto    : '0.19.0-rc.11',
 
             // Serializer
             gson            : '2.10.1',

--- a/ratchet/src/main/kotlin/com/virgilsecurity/ratchet/securechat/SecureSession.kt
+++ b/ratchet/src/main/kotlin/com/virgilsecurity/ratchet/securechat/SecureSession.kt
@@ -102,8 +102,7 @@ class SecureSession {
                     senderIdentityPublicKeyObj,
                     receiverIdentityPrivateKeyObj,
                     receiverLongTermPrivateKeyObj,
-                    ratchetMessage,
-                    false
+                    ratchetMessage
             )
         } else {
             val receiverOneTimePrivateKeyObj = this.crypto.importPrivateKey(receiverOneTimePrivateKey.key).privateKey.privateKey
@@ -112,8 +111,7 @@ class SecureSession {
                     receiverIdentityPrivateKeyObj,
                     receiverLongTermPrivateKeyObj,
                     receiverOneTimePrivateKeyObj,
-                    ratchetMessage,
-                    false
+                    ratchetMessage
             )
         }
     }
@@ -154,8 +152,7 @@ class SecureSession {
                     receiverIdentityPublicKeyObj,
                     receiverIdentityKeyId,
                     receiverLongTermPublicKeyObj,
-                    receiverLongTermKeyId,
-                    false
+                    receiverLongTermKeyId
             )
         } else {
             val receiverOneTimePublicKeyObj = this.crypto.importPublicKey(receiverOneTimePublicKey).publicKey
@@ -167,8 +164,7 @@ class SecureSession {
                     receiverLongTermPublicKeyObj,
                     receiverLongTermKeyId,
                     receiverOneTimePublicKeyObj,
-                    receiverOneTimeKeyId,
-                    false
+                    receiverOneTimeKeyId
             )
         }
     }


### PR DESCRIPTION
## Summary

- Bumps `com.virgilsecurity.sdk:*` from `7.4.0` to `7.5.0`
- Bumps `com.virgilsecurity.crypto:ratchet` and `ratchet-android` from `0.17.2` to `0.19.0-rc.8`
- Bumps `SDK_VERSION` from `0.3.0` to `0.4.0`
- Removes deprecated `.travis.yml` stub

## ⚠️ Dependency

Requires `virgil-sdk-java-android v7.5.0` to be published on Maven Central before CI here can pass. Merge only after sdk-java-android is released.

## Test plan

- [x] sdk-java-android v7.5.0 available on Maven Central
- [x] `build-and-test.yml` CI passes
- [ ] After merge: tag `v0.4.0` → `publish-release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)